### PR TITLE
Be able to build without specifying credentials

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,8 +42,8 @@ publishing {
         maven {
             url "https://api.bintray.com/maven/rundis/maven/gradle-buster-plugin"
                     credentials {
-                        username = bintray_username
-                        password = bintray_api_key
+                        username = hasProperty('bintray_username') ? bintray_username : ''
+                        password = hasProperty('bintray_api_key') ? bintray_api_key : ''
                     }
         }
     }


### PR DESCRIPTION
To deploy the plugin to bintray, a uid/pwd must be set, but for a simple
build it should not be necessary.

Use the project.hasProperty(...) method for checking if the uid/pwd is
set before accessing it, else use an empty string.
